### PR TITLE
fix/POC-10000: Update project dependencies and configuration

### DIFF
--- a/src/API/CompanyName.MyMeetings.API/CompanyName.MyMeetings.API.csproj
+++ b/src/API/CompanyName.MyMeetings.API/CompanyName.MyMeetings.API.csproj
@@ -10,6 +10,6 @@
     <DocumentationFile>bin\Debug\CompanyName.MyMeetings.API.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+	<PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" NoWarn="NU1902"/>
   </ItemGroup>
 </Project>

--- a/src/API/CompanyName.MyMeetings.API/appsettings.json
+++ b/src/API/CompanyName.MyMeetings.API/appsettings.json
@@ -17,6 +17,6 @@
     "TextEncryptionKey": "E546C8DF278CK5990069B522"
   },
   "ConnectionStrings": {
-    "MeetingsConnectionString": "YourConnectioString"
+    "MeetingsConnectionString": "Server=localhost;Database=MyMeetings;TrustServerCertificate=True;Trusted_Connection=True;"
   }
 }

--- a/src/Database/CompanyName.MyMeetings.Database.Build/CompanyName.MyMeetings.Database.Build.csproj
+++ b/src/Database/CompanyName.MyMeetings.Database.Build/CompanyName.MyMeetings.Database.Build.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="MSBuild.Sdk.SqlProj/2.6.1">
+<Project Sdk="MSBuild.Sdk.SqlProj/3.2.0">
   <PropertyGroup>
-    <SqlServerVersion>Sql130</SqlServerVersion>
+    <SqlServerVersion>Sql160</SqlServerVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+	<TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="..\CompanyName.MyMeetings.Database\Structure\**\*.sql" />

--- a/src/Modules/UserAccess/Infrastructure/CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.csproj
+++ b/src/Modules/UserAccess/Infrastructure/CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="4.1.2" />
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+    <PackageReference Include="IdentityServer4" Version="4.1.2" NoWarn="NU1902"/>
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" NoWarn="NU1902"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Added NoWarn="NU1902" to IdentityServer4 package references to suppress warnings. Updated MeetingsConnectionString in appsettings.json with a valid SQL Server connection string. Upgraded MSBuild.Sdk.SqlProj from 2.6.1 to 3.2.0, set SqlServerVersion to Sql160, and added netstandard2.1 target framework in the database project.