### PR TITLE
Update sqlcmd path and add SSL validation argument

### DIFF
--- a/build/BuildIntegrationTests.cs
+++ b/build/BuildIntegrationTests.cs
@@ -68,7 +68,7 @@ public partial class Build
                 .EnableInteractive()
                 .SetContainer("sql-server-db")
                 .SetCommand("/bin/sh")
-                .SetArgs("-c", $"./opt/mssql-tools/bin/sqlcmd -d master -i ./{InputFilesDirectoryName}/{CreateDatabaseScriptName} -U {SqlServerUser} -P {SqlServerPassword}"));
+                .SetArgs("-c", $"/opt/mssql-tools18/bin/sqlcmd -d master -i ./{InputFilesDirectoryName}/{CreateDatabaseScriptName} -U {SqlServerUser} -P {SqlServerPassword} -C"));
         });
 
     Target CompileDbUpMigratorForIntegrationTests => _ => _


### PR DESCRIPTION
Updated the path to the `sqlcmd` tool from `/opt/mssql-tools/bin/sqlcmd` to `/opt/mssql-tools18/bin/sqlcmd` to use the newer version of the SQL tools.

Added the `-C` argument to enforce SSL certificate validation when connecting to the SQL Server, improving security.