### PR TITLE
chore: add GitHub PR automation (/create-pr command, MCP server, PR template)

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -1,0 +1,103 @@
+---
+description: Create a GitHub PR from the current feature branch into master, using the repo's DDD-tailored PR template.
+argument-hint: [optional PR title override]
+allowed-tools: Bash, PowerShell, Read, Edit, Write, Glob, Grep
+---
+
+# /create-pr — feature-branch → master PR automation
+
+You are creating a pull request from the **current local feature branch** into **master** for the modular-monolith DDD repo at `C:\Github\POCs\my-dotnet-poc\ddd`. The user's workflow is: branch from master locally → commit → run this command → review/approve/merge on github.com. Your job is the middle step: surface state, push the branch, and open the PR with a thoughtful title and body.
+
+## Hard rules
+
+1. **Never push to or PR against anything other than `master`.** This repo has no `develop`/`main`/`staging`.
+2. **Never use `--no-verify`, `--force`, `--force-with-lease`, or amend.** If a hook fails, fix it; if push is rejected, stop and tell the user.
+3. **Never commit on the user's behalf in this command.** If there are uncommitted changes, surface them and stop — let the user decide.
+4. **Never invent issue numbers or ADR links.** Use `N/A` if you cannot find a real one.
+5. If `gh` is not installed or not authenticated, stop immediately and tell the user to run `! winget install --id GitHub.cli` and `! gh auth login` (the `!` prefix runs the command in their session).
+
+## Step 1 — Sanity checks (run all in parallel)
+
+Run these and reason about the output before proceeding:
+
+- `git branch --show-current` — confirm we are NOT on `master`
+- `git status --short` — any uncommitted or untracked files?
+- `git log --oneline master..HEAD` — what commits will this PR contain?
+- `git diff master...HEAD --stat` — what files change, how much churn?
+- `git diff master...HEAD --name-only` — for module-detection later
+- `gh auth status` — is `gh` ready?
+
+**Stop and ask the user if any of these are true:**
+- Current branch is `master` → "You're on master. Switch to your feature branch first."
+- There are uncommitted changes → list them and ask "Commit these before opening the PR? Or stash?"
+- `master..HEAD` is empty → "No commits ahead of master — nothing to PR."
+- `gh auth status` errors → walk through the install/auth steps above.
+
+## Step 2 — Detect affected modules
+
+From the changed-files list, infer which boxes to tick in the PR template's **Affected Module(s)** section. Map file paths to modules:
+
+| Path pattern | Tick |
+|---|---|
+| `src/Modules/Meetings/**` | Meetings |
+| `src/Modules/Administration/**` | Administration |
+| `src/Modules/Payments/**` | Payments |
+| `src/Modules/Registrations/**` | Registrations |
+| `src/Modules/UserAccess/**` | UserAccess |
+| `src/BuildingBlocks/**` | BuildingBlocks (cross-cutting) |
+| `src/API/**` | API host / composition |
+| `src/Database/**` | Database scripts |
+
+Also infer **Type of Change** boxes by looking at file paths and diff content (e.g., a new `*.sql` in `src/Database/` → "Database schema"; a new file under `*/IntegrationEvents/` → "Integration event"; a new aggregate or `*Command.cs` → "Command / Write model").
+
+## Step 3 — Draft the title and body
+
+**Title** (≤ 70 chars):
+- If the user passed an argument (`$ARGUMENTS`), use it verbatim.
+- Otherwise derive from the commit log. If there's a single commit, use its subject. If there are several, write a one-line summary in imperative mood. Prefix with the affected module if it's single-module (e.g., `Meetings: add waitlist promotion rule`).
+
+**Body** — read `.github/pull_request_template.md` and fill it in:
+- Pre-tick the affected-module and type-of-change checkboxes you inferred in Step 2.
+- Write a 2-4 sentence **Summary** that explains *why* the change exists (business outcome), then *what* changed at the architectural level. Mine the commit messages, not the diff.
+- Leave **Architecture Compliance** checkboxes UNCHECKED — the user must tick them after self-review. Do not assume any of them.
+- Leave **Tests** checkboxes UNCHECKED for the same reason.
+- Fill **Database Changes** only if `src/Database/**` files changed; otherwise delete the section.
+- **Related**: search the commits and branch name for issue numbers (e.g., `POC-10011` from branch names like `feat/POC-10011`). If none found, write `N/A`.
+
+Show the drafted title + body to the user and ask "Open this PR? (y/n/edit)". Do not skip this confirmation.
+
+## Step 4 — Push the branch and create the PR
+
+After user confirms:
+
+1. Check if upstream exists: `git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>&1`
+2. If no upstream: `git push -u origin HEAD`
+3. If upstream exists: `git push`
+4. If push is rejected, **stop** and report — never force.
+
+Then create the PR. Use a HEREDOC for the body to preserve formatting:
+
+```
+gh pr create --base master --title "<title>" --body "$(cat <<'EOF'
+<filled-in template body>
+EOF
+)"
+```
+
+## Step 5 — Return the URL
+
+Print the PR URL `gh pr create` returns, and end with:
+
+```
+result: opened PR #<num> at <url> against master from <branch> (<N> commits, <M> files changed)
+```
+
+That's the only success signal — the work isn't "done" until that line appears.
+
+## Failure modes — say `failed:` explicitly
+
+- `gh` not installed/authed → `failed: gh CLI not available; run \`! winget install --id GitHub.cli && gh auth login\``
+- On master → `failed: refusing to PR from master into master`
+- No commits ahead → `failed: no commits to PR (master..HEAD is empty)`
+- Push rejected → `failed: push to origin rejected — pull/rebase first, do not force`
+- Hook failure on push → `failed: pre-push hook blocked — fix the underlying issue, do not bypass`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,69 @@
+## Summary
+
+<!-- What changed and why. Lead with the business outcome, not the code mechanics. -->
+
+## Affected Module(s)
+
+<!-- Tick every bounded context this PR touches. Cross-module PRs need careful review (see Architecture Compliance). -->
+
+- [ ] Meetings
+- [ ] Administration
+- [ ] Payments
+- [ ] Registrations
+- [ ] UserAccess
+- [ ] BuildingBlocks (cross-cutting)
+- [ ] API host / composition
+- [ ] Database scripts
+
+## Type of Change
+
+- [ ] Command / Write model (aggregate, command handler, validator)
+- [ ] Query / Read model (Dapper handler, SQL view)
+- [ ] Domain event (intra-module side effect)
+- [ ] Integration event (cross-module contract — **breaking changes need coordination**)
+- [ ] Database schema (new `Database/<schema>/NNNN_*.sql` script — never modify deployed scripts)
+- [ ] Infrastructure / Autofac composition root
+- [ ] Background job (Quartz)
+- [ ] Bug fix
+- [ ] Refactor (no behaviour change)
+- [ ] Docs / ADR
+
+## Architecture Compliance
+
+<!-- These are the rules from CLAUDE.md. If any are unchecked, justify in the PR body. -->
+
+- [ ] No direct cross-module method calls — module-to-module is integration events only
+- [ ] Domain layer has no infrastructure dependencies (pure POCO)
+- [ ] Business logic lives in the aggregate, not the command handler
+- [ ] Invariants enforced via `CheckRule(IBusinessRule)`
+- [ ] Validators use FluentValidation in the Application layer
+- [ ] Query handlers use Dapper + `[schema].[v_*]` views, return DTOs only
+- [ ] Module arch tests pass (`dotnet test src/Modules/{Module}/Tests/ArchTests`)
+- [ ] Cross-module arch tests pass (`dotnet test src/Tests/ArchTests`)
+- [ ] If a non-trivial decision was made: ADR added under `docs/architecture-decision-log/`
+
+## Tests
+
+- [ ] Unit tests (domain — aggregates, value objects, business rules)
+- [ ] Integration tests (handler + real SQL Server)
+- [ ] System integration tests (if cross-module flow changed)
+- [ ] Manual verification via Swagger at `http://localhost:5000/swagger`
+
+## Database Changes
+
+<!-- Delete this section if no DB changes. -->
+
+- Schema: `<module schema>`
+- New scripts: `<list of NNNN_*.sql files>`
+- [ ] Scripts are additive only (no edits to previously-deployed scripts)
+- [ ] Read-model views updated if write model shape changed
+
+## Related
+
+- ADR(s): <link or N/A>
+- Spec: <`docs/spec-driven/...` path or N/A>
+- Issue: <link or N/A>
+
+---
+
+<sub>PR scaffolded against this repo's modular monolith / DDD conventions. See `CLAUDE.md` and `docs/architecture-decision-log/` for the rules behind each checkbox.</sub>

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-mcp.json",
+  "_comment": "Project-scoped MCP servers. Committed to the repo so teammates pick up the same wiring. Tokens are read from env vars — never paste secrets here.",
+  "mcpServers": {
+    "github": {
+      "_comment": "Official GitHub MCP server (github/github-mcp-server) run locally via Docker. Provides mcp__github__* tools for PRs, issues, code search, Actions, etc. Set GITHUB_PERSONAL_ACCESS_TOKEN at user-scope (see docs/copilot-instructions/MCP-SETUP.md) — Docker must be running.",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/docs/copilot-instructions/06-GITHUB-AUTOMATION.md
+++ b/docs/copilot-instructions/06-GITHUB-AUTOMATION.md
@@ -1,0 +1,139 @@
+# 06 — GitHub PR Automation
+
+How this repo talks to GitHub from Claude Code. Two layers, complementary:
+
+| Layer | Backed by | When it runs | What it's good for |
+|---|---|---|---|
+| `/create-pr` slash command | `gh` CLI | You type `/create-pr` in Claude Code | The exact ritual you do every PR: branch sanity, push, open PR with the repo's template |
+| `github` MCP server | `github/github-mcp-server` (Docker) | Auto-starts with Claude Code | Agentic queries — list/inspect PRs and issues, check Actions runs, search code on GitHub |
+
+Both share the same auth (a GitHub Personal Access Token). Set up once, both work.
+
+---
+
+## 1. One-time setup
+
+### 1a. Install `gh` (GitHub CLI)
+
+In an **admin** PowerShell — but actually winget can install user-scope without admin:
+
+```powershell
+winget install --id GitHub.cli --source winget
+```
+
+If winget prompts you to accept Microsoft Store terms, accept once.
+
+Restart your shell so `gh` is on `PATH`. Verify:
+
+```powershell
+gh --version
+```
+
+### 1b. Authenticate `gh`
+
+In Claude Code's prompt, type the next command with the leading `!` so it runs in the live session and you can complete the interactive browser flow:
+
+```
+! gh auth login
+```
+
+Choose: **GitHub.com** → **HTTPS** → **Login with a web browser** → paste the one-time code.
+
+After that:
+
+```powershell
+gh auth status
+```
+
+should show your user and `Token scopes: 'gist', 'read:org', 'repo', 'workflow'`.
+
+### 1c. Make the token available to the GitHub MCP server
+
+The MCP server reads `GITHUB_PERSONAL_ACCESS_TOKEN` from the environment. Reuse the token `gh` already obtained — no need to mint a separate PAT in the GitHub UI:
+
+```powershell
+# Get the token gh stored, set it at user scope so it persists across shells
+setx GITHUB_PERSONAL_ACCESS_TOKEN (gh auth token)
+```
+
+Open a fresh PowerShell / restart Claude Code so it picks up the env var. Verify:
+
+```powershell
+$env:GITHUB_PERSONAL_ACCESS_TOKEN.Length    # should print a number, not 0
+```
+
+> **Why a separate env var?** Because the MCP server runs inside a Docker container — it can't shell out to `gh auth token` itself. The env var is the bridge.
+
+### 1d. Ensure Docker Desktop is running
+
+The MCP server runs as a short-lived Docker container. Docker Desktop must be running for Claude Code to start the server. (You already use Docker MCP Toolkit, so this is likely fine.)
+
+First time Claude Code starts the server, Docker will pull `ghcr.io/github/github-mcp-server` (~one-time download). Subsequent starts are instant.
+
+---
+
+## 2. Daily workflow
+
+### Opening a PR
+
+From a feature branch with committed changes:
+
+```
+/create-pr
+```
+
+The slash command (see `.claude/commands/create-pr.md`) will:
+
+1. Check you're not on `master`, that you have commits ahead of `master`, and that there's nothing uncommitted.
+2. Detect which module(s) you touched and pre-tick those boxes in the PR template.
+3. Draft a title and a body filled in from `.github/pull_request_template.md`.
+4. Show the draft to you for confirmation.
+5. `git push -u origin HEAD`, then `gh pr create --base master ...`.
+6. Print the PR URL.
+
+Optional title override:
+
+```
+/create-pr Meetings: enforce waitlist promotion FIFO order
+```
+
+You then open the PR URL, self-review, approve, merge — same as before.
+
+### Querying GitHub mid-conversation
+
+Once the MCP server is up, Claude has tools like:
+
+| Tool | Use case |
+|---|---|
+| `mcp__github__list_pull_requests` | "What PRs are open?" |
+| `mcp__github__get_pull_request_files` | "What files did PR #5 change?" |
+| `mcp__github__list_issues` | "What's tagged `bug`?" |
+| `mcp__github__list_workflow_runs` | "Did CI pass on this branch?" |
+| `mcp__github__search_code` | "Find every `IBusinessRule` impl on `master`" |
+
+These are no extra effort to use — just ask, and Claude picks the right one.
+
+---
+
+## 3. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `/create-pr` says "gh CLI not available" | `gh` not on PATH | Re-run step 1a, restart shell |
+| `gh pr create` fails with auth error | Token expired | `! gh auth login` again, then re-run `setx GITHUB_PERSONAL_ACCESS_TOKEN (gh auth token)` |
+| Claude doesn't list `mcp__github__*` tools | Env var not set, or Docker not running | Check `$env:GITHUB_PERSONAL_ACCESS_TOKEN` and Docker Desktop, then restart Claude Code |
+| MCP server "exited" in `/mcp` panel | Docker pulling image on first run | Wait ~30s and retry — image is cached after first pull |
+| PR opens but description is empty | Template not picked up | Confirm `.github/pull_request_template.md` exists; `gh` auto-loads it |
+
+---
+
+## 4. What lives where
+
+```
+.github/pull_request_template.md   # The DDD-tailored template (modules, ADRs, arch tests)
+.claude/commands/create-pr.md      # The /create-pr slash command (gh-based)
+.mcp.json                          # Project-scoped MCP servers — currently: github
+docs/copilot-instructions/06-...   # This doc
+```
+
+Tokens and personal Claude settings stay in `.claude/settings.local.json` (gitignored) and Windows env vars — none of this is checked in.


### PR DESCRIPTION
## Summary

Adds local automation for the feature-branch -> PR workflow that we do every day. Three artifacts plus setup docs:

- **`.github/pull_request_template.md`** — DDD-tailored PR template. The checkboxes encode the architecture rules from `CLAUDE.md` (no direct cross-module calls, domain layer has no infra deps, arch tests pass, etc.) so they become PR-time pressure instead of invisible conventions.
- **`.claude/commands/create-pr.md`** — `/create-pr` slash command. Drives the ritual: sanity checks (no master, no uncommitted, gh authed), module detection from changed paths, draft title + body, push, `gh pr create`, return URL. Refuses to force-push or PR into anything other than `master`.
- **`.mcp.json`** — project-scoped GitHub MCP server (`ghcr.io/github/github-mcp-server` via Docker). Token is read from the `GITHUB_PERSONAL_ACCESS_TOKEN` env var at MCP-server-start time — only a `${...}` placeholder is committed.
- **`docs/copilot-instructions/06-GITHUB-AUTOMATION.md`** — one-time setup and daily-workflow docs (install `gh`, auth, token bridging, troubleshooting).

No code changes; pure tooling addition.

## Affected Module(s)

<!-- None — this PR is repo-level tooling, not module work. -->

- [ ] Meetings
- [ ] Administration
- [ ] Payments
- [ ] Registrations
- [ ] UserAccess
- [ ] BuildingBlocks (cross-cutting)
- [ ] API host / composition
- [ ] Database scripts

## Type of Change

- [ ] Command / Write model (aggregate, command handler, validator)
- [ ] Query / Read model (Dapper handler, SQL view)
- [ ] Domain event (intra-module side effect)
- [ ] Integration event (cross-module contract — **breaking changes need coordination**)
- [ ] Database schema (new `Database/<schema>/NNNN_*.sql` script — never modify deployed scripts)
- [ ] Infrastructure / Autofac composition root
- [ ] Background job (Quartz)
- [ ] Bug fix
- [ ] Refactor (no behaviour change)
- [x] Docs / ADR

## Architecture Compliance

<!-- This PR is tooling-only. No source code touched, so the runtime architecture rules don't apply. Reviewer should still verify the template's checkbox text matches the rules in CLAUDE.md (i.e., the template stays in sync with the project's architecture decisions). -->

- [ ] No direct cross-module method calls — module-to-module is integration events only
- [ ] Domain layer has no infrastructure dependencies (pure POCO)
- [ ] Business logic lives in the aggregate, not the command handler
- [ ] Invariants enforced via `CheckRule(IBusinessRule)`
- [ ] Validators use FluentValidation in the Application layer
- [ ] Query handlers use Dapper + `[schema].[v_*]` views, return DTOs only
- [ ] Module arch tests pass (`dotnet test src/Modules/{Module}/Tests/ArchTests`)
- [ ] Cross-module arch tests pass (`dotnet test src/Tests/ArchTests`)
- [ ] If a non-trivial decision was made: ADR added under `docs/architecture-decision-log/`

## Tests

<!-- Manual verification only — the automation either works or it doesn't when you invoke it. -->

- [ ] Unit tests (domain — aggregates, value objects, business rules)
- [ ] Integration tests (handler + real SQL Server)
- [ ] System integration tests (if cross-module flow changed)
- [ ] Manual verification: invoke `/create-pr` on a feature branch and confirm it opens a PR with the template populated

## Related

- ADR(s): N/A
- Spec: N/A
- Issue: POC-10013 (Jira)

---

<sub>PR scaffolded against this repo's modular monolith / DDD conventions. See `CLAUDE.md` and `docs/architecture-decision-log/` for the rules behind each checkbox.</sub>
