### PR TITLE
[scanner] fix: remove permission bypass that grants all access in Release builds

### DIFF
--- a/src/API/CompanyName.MyMeetings.API/Configuration/Authorization/HasPermissionAuthorizationHandler.cs
+++ b/src/API/CompanyName.MyMeetings.API/Configuration/Authorization/HasPermissionAuthorizationHandler.cs
@@ -37,12 +37,7 @@ namespace CompanyName.MyMeetings.API.Configuration.Authorization
 
         private Task<bool> AuthorizeAsync(string permission, List<UserPermissionDto> permissions)
         {
-#if !DEBUG
-            return Task.FromResult(true);
-#endif
-#pragma warning disable CS0162 // Unreachable code detected
             return Task.FromResult(permissions.Any(x => x.Code == permission));
-#pragma warning restore CS0162 // Unreachable code detected
         }
     }
 }


### PR DESCRIPTION
## Fix

`HasPermissionAuthorizationHandler.AuthorizeAsync()` contained a `#if !DEBUG / return Task.FromResult(true)` block that unconditionally granted authorization in every non-DEBUG (Release/Production) build. This rendered every API endpoint decorated with `[HasPermission]` completely open to any authenticated caller, bypassing the actual permission check entirely.

The `#pragma CS0162` (unreachable code) comment in the original code confirms the author was aware of the issue but had the bypass and check inverted.

**Change:** Remove the `#if !DEBUG` block entirely. The permission check now runs in all build configurations.

Fixes #14

---
*Filed by scanner agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*