### PR TITLE
[scanner] fix: add global.json to pin SDK to net10.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
## Fix

Adds `global.json` at the repository root to pin the .NET SDK to `10.0.x` with `rollForward: latestMinor`. This keeps `build.sh` and IDE tooling aligned with the `net10.0` target declared in `src/Directory.Build.props`.

### Still needed (requires `workflow` token scope)

`buildPipeline.yml` still has `dotnet-version: 8.0.x` in both the `build` and `integration` jobs. This must be changed to `10.0.x` manually or by a token with `workflow` scope:

```yaml
- name: Setup .NET
  uses: actions/setup-dotnet@v4
  with:
    dotnet-version: 10.0.x  # was 8.0.x
```

Also recommended: add `workflow_dispatch:` to the `on:` block to allow manual pipeline runs.

Fixes #15

---
*Filed by scanner agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*