### PR TITLE
[scanner] fix: enable SubscriptionLifecycleTests and fix flaky renewal-payment probe

### DIFF
--- a/src/Modules/Payments/Tests/IntegrationTests/Subscriptions/SubscriptionLifecycleTests.cs
+++ b/src/Modules/Payments/Tests/IntegrationTests/Subscriptions/SubscriptionLifecycleTests.cs
@@ -18,7 +18,6 @@ namespace CompanyName.MyMeetings.Modules.Payments.IntegrationTests.Subscriptions
 {
     [NonParallelizable]
     [TestFixture]
-    [Ignore("Sometimes fails, to check why")]
     public class SubscriptionLifecycleTests : TestBase
     {
         [Test]
@@ -101,7 +100,8 @@ namespace CompanyName.MyMeetings.Modules.Payments.IntegrationTests.Subscriptions
                 new GetSubscriptionPaymentsProbe(
                     PaymentsModule,
                     ExecutionContext.UserId,
-                    x => x.Any(y => y.PaymentId == subscriptionRenewalPaymentId)),
+                    x => x.Any(y => y.PaymentId == subscriptionRenewalPaymentId &&
+                                    y.Status == SubscriptionRenewalPaymentStatus.Paid.Code)),
                 10000);
 
             renewalPayment = subscriptionPayments


### PR DESCRIPTION
## Fix

Remove the `[Ignore]` attribute from `SubscriptionLifecycleTests` and fix the root-cause race condition that caused intermittent failures.

The probe after `MarkSubscriptionRenewalPaymentAsPaidCommand` used `x.Any(y => y.PaymentId == subscriptionRenewalPaymentId)`, which was already satisfied before the command ran (the renewal payment record existed in WaitingForPayment state). The probe returned immediately with stale data, causing the subsequent status assertion to race against the async update.

The fix changes the probe to wait until `Status == Paid.Code`, ensuring the read model reflects the command result before assertions run. `SystemClock.Reset()` is already in `TestBase.AfterEachTest()` teardown.

Fixes #20

---
*Filed by scanner agent (ACMM L5 - hold-gated mode). Hold-gated: human review required.*