### PR TITLE
[scanner] fix: add payments and registrations schema polling to AsyncOperationsHelper

### DIFF
--- a/src/Tests/SUT/SeedWork/AsyncOperationsHelper.cs
+++ b/src/Tests/SUT/SeedWork/AsyncOperationsHelper.cs
@@ -71,8 +71,50 @@ namespace CompanyName.MyMeetings.SUT.SeedWork
 
                 var outboxCountMeetingsAdministration = await sqlConnection.ExecuteScalarAsync<int>(
                     """
-                    SELECT COUNT(*) 
-                    FROM [administration].[OutboxMessages] AS [OutboxMessage] 
+                    SELECT COUNT(*)
+                    FROM [administration].[OutboxMessages] AS [OutboxMessage]
+                    WHERE [OutboxMessage].[ProcessedDate] IS NULL
+                    """);
+
+                var internalCommandsCountPayments = await sqlConnection.ExecuteScalarAsync<int>(
+                    """
+                    SELECT COUNT(*)
+                    FROM [payments].[InternalCommands] AS [InternalCommand]
+                    WHERE [InternalCommand].[ProcessedDate] IS NULL
+                    """);
+
+                var inboxCountPayments = await sqlConnection.ExecuteScalarAsync<int>(
+                    """
+                    SELECT COUNT(*)
+                    FROM [payments].[InboxMessages] AS [InboxMessage]
+                    WHERE [InboxMessage].[ProcessedDate] IS NULL
+                    """);
+
+                var outboxCountPayments = await sqlConnection.ExecuteScalarAsync<int>(
+                    """
+                    SELECT COUNT(*)
+                    FROM [payments].[OutboxMessages] AS [OutboxMessage]
+                    WHERE [OutboxMessage].[ProcessedDate] IS NULL
+                    """);
+
+                var internalCommandsCountRegistrations = await sqlConnection.ExecuteScalarAsync<int>(
+                    """
+                    SELECT COUNT(*)
+                    FROM [registrations].[InternalCommands] AS [InternalCommand]
+                    WHERE [InternalCommand].[ProcessedDate] IS NULL
+                    """);
+
+                var inboxCountRegistrations = await sqlConnection.ExecuteScalarAsync<int>(
+                    """
+                    SELECT COUNT(*)
+                    FROM [registrations].[InboxMessages] AS [InboxMessage]
+                    WHERE [InboxMessage].[ProcessedDate] IS NULL
+                    """);
+
+                var outboxCountRegistrations = await sqlConnection.ExecuteScalarAsync<int>(
+                    """
+                    SELECT COUNT(*)
+                    FROM [registrations].[OutboxMessages] AS [OutboxMessage]
                     WHERE [OutboxMessage].[ProcessedDate] IS NULL
                     """);
 
@@ -84,7 +126,13 @@ namespace CompanyName.MyMeetings.SUT.SeedWork
                     outboxCountMeetings == 0 &&
                     internalCommandsCountAdministration == 0 &&
                     inboxCountMeetingsAdministration == 0 &&
-                    outboxCountMeetingsAdministration == 0)
+                    outboxCountMeetingsAdministration == 0 &&
+                    internalCommandsCountPayments == 0 &&
+                    inboxCountPayments == 0 &&
+                    outboxCountPayments == 0 &&
+                    internalCommandsCountRegistrations == 0 &&
+                    inboxCountRegistrations == 0 &&
+                    outboxCountRegistrations == 0)
                 {
                     return;
                 }


### PR DESCRIPTION
## Fix

`AsyncOperationsHelper.WaitForProcessing()` polled only `users`, `meetings`, and `administration` schemas. SUT integration tests that cross into the Payments or Registrations modules would not wait for those queues to drain, causing silent race conditions where tests assert final state before cross-module events finish processing.

Add polling for all six missing tables (`payments.InternalCommands`, `payments.InboxMessages`, `payments.OutboxMessages`, `registrations.InternalCommands`, `registrations.InboxMessages`, `registrations.OutboxMessages`) following the identical pattern used for the three existing schemas.

Fixes #21

---
*Filed by scanner agent (ACMM L5 - hold-gated mode). Hold-gated: human review required.*