### PR TITLE
[scanner] fix: add User.Deactivate() to make inactive-user guard reachable

### DIFF
--- a/src/Modules/UserAccess/Domain/Users/Events/UserDeactivatedDomainEvent.cs
+++ b/src/Modules/UserAccess/Domain/Users/Events/UserDeactivatedDomainEvent.cs
@@ -1,0 +1,14 @@
+using CompanyName.MyMeetings.BuildingBlocks.Domain;
+
+namespace CompanyName.MyMeetings.Modules.UserAccess.Domain.Users.Events
+{
+    public class UserDeactivatedDomainEvent : DomainEventBase
+    {
+        public UserDeactivatedDomainEvent(UserId id)
+        {
+            Id = id;
+        }
+
+        public new UserId Id { get; }
+    }
+}

--- a/src/Modules/UserAccess/Domain/Users/User.cs
+++ b/src/Modules/UserAccess/Domain/Users/User.cs
@@ -13,9 +13,7 @@ namespace CompanyName.MyMeetings.Modules.UserAccess.Domain.Users
 
         private string _email;
 
-#pragma warning disable CS0414 // Field is assigned but its value is never used
         private bool _isActive;
-#pragma warning restore CS0414 // Field is assigned but its value is never used
 
         private string _firstName;
 
@@ -91,6 +89,13 @@ namespace CompanyName.MyMeetings.Modules.UserAccess.Domain.Users
             _roles = [role];
 
             this.AddDomainEvent(new UserCreatedDomainEvent(this.Id));
+        }
+
+        public void Deactivate()
+        {
+            _isActive = false;
+
+            this.AddDomainEvent(new UserDeactivatedDomainEvent(this.Id));
         }
     }
 }


### PR DESCRIPTION
## Fix

Add `User.Deactivate()` domain method that sets `_isActive = false` and raises `UserDeactivatedDomainEvent`. Also creates `UserDeactivatedDomainEvent`.

`User._isActive` was always `true` because neither `CreateUser()` nor `CreateAdmin()` provided a deactivation path. The `!user.IsActive` check in `AuthenticateCommandHandler` was permanently unreachable dead code, and the `#pragma warning disable CS0414` suppression masked the compiler evidence.

With this fix, the authentication guard in `AuthenticateCommandHandler` is reachable once a `DeactivateUserCommand` (to be added as a follow-up) calls `user.Deactivate()`. The pragma suppression is removed.

Fixes #18

---
*Filed by scanner agent (ACMM L5 - hold-gated mode). Hold-gated: human review required.*