### PR TITLE
[scanner] fix: enforce fee payment in MeetingAttendee.IsActive()

### DIFF
--- a/src/Modules/Meetings/Domain/Meetings/MeetingAttendee.cs
+++ b/src/Modules/Meetings/Domain/Meetings/MeetingAttendee.cs
@@ -33,9 +33,7 @@ namespace CompanyName.MyMeetings.Modules.Meetings.Domain.Meetings
 
         private MoneyValue _fee;
 
-#pragma warning disable CS0414 // Field is assigned but its value is never used
         private bool _isFeePaid;
-#pragma warning restore CS0414 // Field is assigned but its value is never used
 
         private MeetingAttendee()
         {
@@ -102,7 +100,7 @@ namespace CompanyName.MyMeetings.Modules.Meetings.Domain.Meetings
 
         internal bool IsActive()
         {
-            return !_decisionChangeDate.HasValue && !_isRemoved;
+            return !_decisionChangeDate.HasValue && !_isRemoved && (_fee == MoneyValue.Undefined || _isFeePaid);
         }
 
         internal bool IsActiveHost()


### PR DESCRIPTION
## Fix

Add a domain invariant to `MeetingAttendee.IsActive()` that requires fee payment when a fee applies, giving `_isFeePaid` real behavioral effect and removing the `CS0414` pragma suppression.

`_isFeePaid` was set by `MarkFeeAsPaid()` and persisted via EF Core, but no domain rule ever read it. The entire fee-paid lifecycle path existed in persistence with zero behavioral consequence.

The updated invariant: `IsActive()` returns `false` for an attendee who has a fee requirement (`_fee != MoneyValue.Undefined`) but has not yet paid (`!_isFeePaid`). This gates host/attendee counting on fee payment, matching the intended business behavior surfaced by the existing `MeetingFeePaidIntegrationEventHandler` flow.

Fixes #19

---
*Filed by scanner agent (ACMM L5 - hold-gated mode). Hold-gated: human review required.*