### PR TITLE
[sec-check] fix: raise PBKDF2 password-hash iterations to 600,000

### DIFF
--- a/src/Modules/Registrations/Application/UserRegistrations/RegisterNewUser/PasswordManager.cs
+++ b/src/Modules/Registrations/Application/UserRegistrations/RegisterNewUser/PasswordManager.cs
@@ -7,7 +7,7 @@ namespace CompanyName.MyMeetings.Modules.Registrations.Application.UserRegistrat
     {
         private const int SaltSize = 0x10; // 16 bytes
         private const int HashSize = 0x20; // 32 bytes
-        private const int Iterations = 0x3e8; // 1000 iterations
+        private const int Iterations = 600_000; // OWASP minimum for PBKDF2-HMAC-SHA256
 
         public static string HashPassword(string password)
         {

--- a/src/Modules/UserAccess/Application/Authentication/Authenticate/PasswordManager.cs
+++ b/src/Modules/UserAccess/Application/Authentication/Authenticate/PasswordManager.cs
@@ -7,7 +7,7 @@ namespace CompanyName.MyMeetings.Modules.UserAccess.Application.Authentication.A
     {
         private const int SaltSize = 0x10; // 16 bytes
         private const int HashSize = 0x20; // 32 bytes
-        private const int Iterations = 0x3e8; // 1000 iterations
+        private const int Iterations = 600_000; // OWASP minimum for PBKDF2-HMAC-SHA256
 
         public static string HashPassword(string password)
         {


### PR DESCRIPTION
## Security Fix

Raises the PBKDF2-HMAC-SHA256 work factor from **1,000** to **600,000** iterations in both password-hashing implementations:

- `src/Modules/UserAccess/Application/Authentication/Authenticate/PasswordManager.cs`
- `src/Modules/Registrations/Application/UserRegistrations/RegisterNewUser/PasswordManager.cs`

1,000 iterations is ~600x below the OWASP-recommended minimum, making offline brute-force of leaked hashes far cheaper.

### Safety / compatibility
- Hashes are generated and verified at runtime via the same `Iterations` constant, and no precomputed password hashes are seeded anywhere in the repo — so this change is internally consistent and does not break the build or tests.
- **Caveat for real deployments:** the stored format `[0x00][salt][hash]` does not encode the iteration count, so it cannot transparently verify hashes created under the old work factor. A deployment with already-persisted user hashes would need a versioned hash format and re-hash-on-login. Flagged in the issue for follow-up design.

Fixes #32

---
*Filed by sec-check agent (ACMM L4/L5 — hold-gated mode). Hold-gated: human review required. Do not merge without addressing the persisted-hash migration note above.*
