### PR TITLE
[architect] refactor: enforce Domain->Infrastructure isolation in ArchTests

### DIFF
--- a/src/Modules/Administration/Tests/ArchTests/Module/LayersTests.cs
+++ b/src/Modules/Administration/Tests/ArchTests/Module/LayersTests.cs
@@ -23,7 +23,7 @@ namespace CompanyName.MyMeetings.Modules.Administration.ArchTests.Module
         {
             var result = Types.InAssembly(DomainAssembly)
                 .Should()
-                .NotHaveDependencyOn(ApplicationAssembly.GetName().Name)
+                .NotHaveDependencyOn(InfrastructureAssembly.GetName().Name)
                 .GetResult();
 
             AssertArchTestResult(result);

--- a/src/Modules/Meetings/Tests/ArchTests/Module/LayersTests.cs
+++ b/src/Modules/Meetings/Tests/ArchTests/Module/LayersTests.cs
@@ -23,7 +23,7 @@ namespace CompanyName.MyMeetings.Modules.Meetings.ArchTests.Module
         {
             var result = Types.InAssembly(DomainAssembly)
                 .Should()
-                .NotHaveDependencyOn(ApplicationAssembly.GetName().Name)
+                .NotHaveDependencyOn(InfrastructureAssembly.GetName().Name)
                 .GetResult();
 
             AssertArchTestResult(result);

--- a/src/Modules/Payments/Tests/ArchTests/Module/LayersTests.cs
+++ b/src/Modules/Payments/Tests/ArchTests/Module/LayersTests.cs
@@ -23,7 +23,7 @@ namespace CompanyName.MyMeetings.Modules.Payments.ArchTests.Module
         {
             var result = Types.InAssembly(DomainAssembly)
                 .Should()
-                .NotHaveDependencyOn(ApplicationAssembly.GetName().Name)
+                .NotHaveDependencyOn(InfrastructureAssembly.GetName().Name)
                 .GetResult();
 
             AssertArchTestResult(result);

--- a/src/Modules/Registrations/Tests/ArchTests/Module/LayersTests.cs
+++ b/src/Modules/Registrations/Tests/ArchTests/Module/LayersTests.cs
@@ -23,7 +23,7 @@ namespace CompanyName.MyMeetings.Modules.Registrations.ArchTests.Module
         {
             var result = Types.InAssembly(DomainAssembly)
                 .Should()
-                .NotHaveDependencyOn(ApplicationAssembly.GetName().Name)
+                .NotHaveDependencyOn(InfrastructureAssembly.GetName().Name)
                 .GetResult();
 
             AssertArchTestResult(result);

--- a/src/Modules/UserAccess/Tests/ArchTests/Module/LayersTests.cs
+++ b/src/Modules/UserAccess/Tests/ArchTests/Module/LayersTests.cs
@@ -23,7 +23,7 @@ namespace CompanyName.MyMeetings.Modules.UserAccess.ArchTests.Module
         {
             var result = Types.InAssembly(DomainAssembly)
                 .Should()
-                .NotHaveDependencyOn(ApplicationAssembly.GetName().Name)
+                .NotHaveDependencyOn(InfrastructureAssembly.GetName().Name)
                 .GetResult();
 
             AssertArchTestResult(result);


### PR DESCRIPTION
## Refactor

In every module's `Tests/ArchTests/Module/LayersTests.cs`, the test `DomainLayer_DoesNotHaveDependency_ToInfrastructureLayer` asserted `NotHaveDependencyOn(ApplicationAssembly.GetName().Name)` — a copy-paste of the preceding `ToApplicationLayer` test. As a result the **Domain -> Infrastructure** layering invariant (a core Clean/Onion architecture rule) was enforced **nowhere** across the solution.

This points each of the five tests at `InfrastructureAssembly` (already defined in each `ArchTests/SeedWork/TestBase.cs` as `typeof(<Module>Context).Assembly`). One line changed per module; no production code touched.

Files:
- src/Modules/Administration/Tests/ArchTests/Module/LayersTests.cs
- src/Modules/Meetings/Tests/ArchTests/Module/LayersTests.cs
- src/Modules/Payments/Tests/ArchTests/Module/LayersTests.cs
- src/Modules/Registrations/Tests/ArchTests/Module/LayersTests.cs
- src/Modules/UserAccess/Tests/ArchTests/Module/LayersTests.cs

Fixes #38

> Note: this agent cannot build/run the .NET 10 test suite in its environment. The corrected tests are expected to pass (Domain has no Infrastructure dependency); if CI surfaces a failure, that is a genuine layering violation worth reviewing.

---
*Filed by architect agent (ACMM L5 — hold-gated mode). Hold-gated: human review required. Do not merge; do not remove the `hold` label.*