### PR TITLE
[scanner] fix: remove global NU1902/NU1903 suppression to expose EOL IdentityServer4

### DIFF
--- a/src/API/CompanyName.MyMeetings.API/CompanyName.MyMeetings.API.csproj
+++ b/src/API/CompanyName.MyMeetings.API/CompanyName.MyMeetings.API.csproj
@@ -10,6 +10,6 @@
     <DocumentationFile>bin\Debug\CompanyName.MyMeetings.API.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-	<PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" NoWarn="NU1902"/>
+	<PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release;Production</Configurations>
-    <NoWarn>1591;1701;1702;8032;NU1701;AD0001;NU5128;NU1603;NU1902;NU1903</NoWarn>
+    <NoWarn>1591;1701;1702;8032;NU1701;AD0001;NU5128;NU1603</NoWarn>
     <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Deterministic>true</Deterministic>

--- a/src/Modules/UserAccess/Infrastructure/CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.csproj
+++ b/src/Modules/UserAccess/Infrastructure/CompanyName.MyMeetings.Modules.UserAccess.Infrastructure.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="IdentityServer4" Version="4.1.2" NoWarn="NU1902"/>
-    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" NoWarn="NU1902"/>
+    <PackageReference Include="IdentityServer4" Version="4.1.2" />
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Fix

Global `NU1902;NU1903` suppression in `src/Directory.Build.props` (alongside `TreatWarningsAsErrors=true`) silently disabled the entire build-time dependency vulnerability gate. This hid that the authentication stack runs on **IdentityServer4 4.1.2** — end-of-life since 2022 with no security patches.

**Changes:**
- Remove `NU1902;NU1903` from global `<NoWarn>` in `src/Directory.Build.props`
- Remove per-package `NoWarn="NU1902"` from `IdentityServer4` and `IdentityServer4.AccessTokenValidation` in `UserAccess.Infrastructure.csproj` and `API.csproj`

**⚠️ CI will fail after this merge** until IdentityServer4 is migrated to a maintained alternative (Duende IdentityServer / OpenIddict). This is the intended signal — the EOL dependency was silently reaching production.

Next step: plan and execute migration away from IdentityServer4 4.1.2.

Fixes #31

---
*Filed by scanner agent (ACMM L5 — hold-gated mode). Hold-gated: human review required.*